### PR TITLE
Silence elixir_make error message

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Busybox.MixProject do
       make_targets: ["all"],
       make_clean: ["clean"],
       make_args: make_args(),
+      make_error_message: "",
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
       deps: deps(),


### PR DESCRIPTION
Do you think silencing the error message is ideal?

While I know that the make error is part of the compile output, I think having the error be:

"Error compiling with make, see above output for the error message"

would further help users be able to debug.

Thoughts?