### PR TITLE
Remove parallel builds

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,6 @@ defmodule Busybox.MixProject do
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_args: make_args(),
       make_error_message: "",
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
@@ -63,10 +62,5 @@ defmodule Busybox.MixProject do
       source_ref: "v#{@version}",
       source_url: "https://github.com/nerves-networking/elixir_busybox"
     ]
-  end
-
-  defp make_args do
-    # Tell make to use all cores when building
-    ["-j", to_string(:erlang.system_info(:schedulers))]
   end
 end


### PR DESCRIPTION
Parallel builds are really challenging on OSX for some reason. See #7.
Since it doesn't appear like this is going to be addressed in a user
friendly way anytime soon, comment the parallel build line out. It only
happens when compiling deps for the first time, so the build time is
annoying, but not an every build thing.

Fixes #7.